### PR TITLE
Add demo to bower.json ignores

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,8 @@
         "node_modules",
         "bower_components",
         "test",
-        "tests"
+        "tests",
+        "demo"
     ],
     "keywords": ["Polymer", "web-components", "datepicker", "html", "pikaday"],
     "dependencies": {


### PR DESCRIPTION
As it is not needed in production, so it will not appear in installed package