### PR TITLE
Update to Polymer 1.8, use Shadow DOM v1 syntax

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     ],
     "keywords": ["Polymer", "web-components", "datepicker", "html", "pikaday"],
     "dependencies": {
-        "polymer": "Polymer/polymer#^1.2.*",
+        "polymer": "^1.8.*",
         "pikaday": "1.5.*",
         "momentjs": "2.*"
     },

--- a/pikaday-decorator.html
+++ b/pikaday-decorator.html
@@ -5,7 +5,7 @@
 
 <dom-module id="pikaday-decorator">
     <template>
-        <content></content>
+        <slot></slot>
     </template>
 </dom-module>
 <script>


### PR DESCRIPTION
To be forward compatible with Web Components V1 and Polymer 2.0